### PR TITLE
release v1.1.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Unreleased] 1.0.2
+## [1.1.0] - 2022-10-06
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nornir_netconf"
-version = "1.0.1"
+version = "1.1.0"
 description = "Netconf plugin for nornir using ncclient"
 authors = ["Hugo Tinoco <hugotinoco@icloud.com>", "Patrick Ogenstad <patrick@ogenstad.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## [1.1.0] - 2022-10-06

### Added

- Normalized the result output between vendors to include 'ok' key

### Changed

- Containerlab IP addresses for local integration testings changed
- Added env variable to docker-compose to run integration tests in containers
- Ability to run all tests from pytest or container
- Tests showing how to use the `extras` for defining the `platform` as the key of `name`

### Fixed

- GH Actions Badge was pointing to previous fork on the Nornir organization
