### PR TITLE
Release v2.1.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2024-10-13
+
+- Deprecation of Python 3.8
+- Formatting Changes with Black
+- Updated CI/CD to use `ruff check`
+
 ## [2.0.0] - 2022-03-14
 
 ### Added


### PR DESCRIPTION
## [2.1.0] - 2024-10-13

- Deprecation of Python 3.8
- Formatting Changes with Black
- Updated CI/CD to use `ruff check`
